### PR TITLE
Normalize paths before use

### DIFF
--- a/lib/raneto.js
+++ b/lib/raneto.js
@@ -131,6 +131,7 @@ var raneto = {
     var category_sort  = raneto.config.category_sort || false;
     var files          = glob.sync(raneto.config.content_dir +'**/*');
     var filesProcessed = [];
+    var content_dir    = path.normalize(raneto.config.content_dir);
 
     filesProcessed.push({
       slug     : '.',
@@ -143,7 +144,7 @@ var raneto = {
 
     files.forEach(function (filePath) {
 
-      var shortPath = filePath.replace(raneto.config.content_dir, '').trim();
+      var shortPath = path.normalize(filePath).replace(content_dir, '').trim();
       var stat      = fs.lstatSync(filePath);
 
       if (stat.isSymbolicLink()) {


### PR DESCRIPTION
Normalize `config.content_dir` and `glob.sync()` paths to uniform slashes. Fixes gilbitron/Raneto#107.
Unfortunately I'm not able to test this change in a linux system, but I believe it should work well.