### PR TITLE
YAML support for meta information

### DIFF
--- a/lib/raneto.js
+++ b/lib/raneto.js
@@ -11,6 +11,7 @@ var _s        = require('underscore.string');
 var marked    = require('marked');
 var lunr      = require('lunr');
 //var validator = require('validator');
+var yaml      = require('yamljs');
 
 var raneto = {
 
@@ -36,6 +37,7 @@ var raneto = {
 
   // Regex for page meta (considers Byte Order Mark \uFEFF in case there's one)
   _metaRegex: /^\uFEFF?\/\*([\s\S]*?)\*\//i,
+  _metaRegexYaml: /\uFEFF?\s*([^]*)---/i,
 
   // Makes filename safe strings
   cleanString: function (str, use_underscore) {
@@ -57,18 +59,46 @@ var raneto = {
   // Get meta information from Markdown content
   processMeta: function (markdownContent) {
 
-    var metaArr    = markdownContent.match(raneto._metaRegex);
     var meta       = {};
-    var metaString = metaArr ? metaArr[1].trim() : '';
+    var metaArr;
+    var metaString;
+    var metas;
 
-    if (metaString) {
-      var metas = metaString.match(/(.*): (.*)/ig);
-      metas.forEach(function (item) {
-        var parts = item.split(': ');
-        if (parts[0] && parts[1]) {
-          meta[raneto.cleanString(parts[0], true)] = parts[1].trim();
+    var yamlObject;
+    var yamlField;
+
+    switch (true) {
+      case raneto._metaRegex.test(markdownContent):
+        metaArr    = markdownContent.match(raneto._metaRegex);
+        metaString = metaArr ? metaArr[1].trim() : '';
+
+        if (metaString) {
+          metas = metaString.match(/(.*): (.*)/ig);
+          metas.forEach(function (item) {
+            var parts = item.split(': ');
+            if (parts[0] && parts[1]) {
+              meta[raneto.cleanString(parts[0], true)] = parts[1].trim();
+            }
+          });
         }
-      });
+        break;
+
+      case raneto._metaRegexYaml.test(markdownContent):
+        metaArr    = markdownContent.match(raneto._metaRegexYaml);
+        metaString = metaArr ? metaArr[1].trim() : '';
+
+        yamlObject = yaml.parse(metaString);
+
+        for (yamlField in yamlObject) {
+          if (yamlObject.hasOwnProperty(yamlField)) {
+            meta[raneto.cleanString(yamlField, true)] = ('' + yamlObject[yamlField]).trim();
+          }
+        }
+
+        break;
+
+      default:
+        // No meta information
     }
 
     return meta;
@@ -77,7 +107,14 @@ var raneto = {
 
   // Strip meta from Markdown content
   stripMeta: function (markdownContent) {
-    return markdownContent.replace(raneto._metaRegex, '').trim();
+    switch (true) {
+      case raneto._metaRegex.test(markdownContent):
+        return markdownContent.replace(raneto._metaRegex, '').trim();
+      case raneto._metaRegexYaml.test(markdownContent):
+        return markdownContent.replace(raneto._metaRegexYaml, '').trim();
+      default:
+        return markdownContent.trim();
+    }
   },
 
   // Replace content variables in Markdown content

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "moment": "2.11.2",
     "underscore": "1.8.3",
     "underscore.string": "3.2.3",
-    "validator": "4.8.0"
+    "validator": "4.8.0",
+    "yamljs": "^0.2.7"
   },
   "devDependencies": {
     "chai": "3.5.0",

--- a/test/content/page-with-bom-yaml.md
+++ b/test/content/page-with-bom-yaml.md
@@ -1,0 +1,5 @@
+﻿Title: Example Page With BOM for YAML
+Sort: 3
+---
+
+This is some example content if a file that has a [BOM](https://en.wikipedia.org/wiki/Byte_order_mark) character.

--- a/test/raneto.js
+++ b/test/raneto.js
@@ -73,6 +73,25 @@ describe('#processMeta()', function () {
     expect(result).to.have.property('title', 'Example Page With BOM');
   });
 
+  it('returns array of meta values (YAML)', function () {
+    var result = raneto.processMeta('\n'+
+      'Title: This is a title\n'+
+      'Description: This is a description\n'+
+      'Sort: 4\n'+
+      'Multi word: Value\n'+
+      '---\n');
+    expect(result).to.have.property('title', 'This is a title');
+    expect(result).to.have.property('description', 'This is a description');
+    expect(result).to.have.property('sort', '4');
+    expect(result).to.have.property('multi_word', 'Value');
+  });
+
+  it('returns proper meta from file starting with a BOM character (YAML)', function () {
+    raneto.config.content_dir = __dirname + '/content/';
+    var result = raneto.getPage(raneto.config.content_dir + 'page-with-bom-yaml.md');
+    expect(result).to.have.property('title', 'Example Page With BOM for YAML');
+  });
+
 });
 
 describe('#stripMeta()', function () {
@@ -162,7 +181,7 @@ describe('#doSearch()', function () {
   it('returns an array of search results', function () {
     raneto.config.content_dir = __dirname + '/content/';
     var result = raneto.doSearch('example');
-    expect(result).to.have.length(3);
+    expect(result).to.have.length(4);
   });
 
   it('returns an empty array if nothing found', function () {


### PR DESCRIPTION
Hello, I'd like to suggest basic implementation of YAML for meta information for gilbitron/Raneto#18. It uses jeremyfa's [YAML parsing & encoding library](https://github.com/jeremyfa/yaml.js) to handle YAML markup.

If I'm not mistaken, there are two points of interest:
1. Parsing meta from Markdown text into JavaScript object for further use
2. Stripping meta block from Markdown

Both of these got implementation. Unit tests were adapted as well.
Please, review this input and let me know if there're any concerns or comments.