### PR TITLE
Add ability to sort by a non-numeric meta field

### DIFF
--- a/lib/raneto.js
+++ b/lib/raneto.js
@@ -27,8 +27,8 @@ var raneto = {
     image_url: '/images',
     // Excerpt length (used in search)
     excerpt_length: 400,
-    // The meta value by which to sort pages (value should be an integer)
-    // If this option is blank pages will be sorted alphabetically
+    // The meta value by which to sort pages (value may be an integer or sortable string)
+    // If this option is blank pages will be sorted alphabetically by filename
     page_sort_meta: 'sort',
     // Should categories be sorted numerically (true) or alphabetically (false)
     // If true category folders need to contain a "sort" file with an integer value
@@ -239,7 +239,13 @@ var raneto = {
           var meta = raneto.processMeta(file.toString('utf-8'));
 
           if (page_sort_meta && meta[page_sort_meta]) {
+            // If it's a number
             pageSort = parseInt(meta[page_sort_meta], 10);
+
+            // If it's a string to sort by
+            if (isNaN(pageSort)) {
+              pageSort = meta[page_sort_meta];
+            }
           }
 
           var val = _.find(filesProcessed, function (item) { return item.slug === dir; });


### PR DESCRIPTION
If `page_sort_meta` is a numeric field, it sorts by the number. If it is an alphanumeric field, it sorts by the string.