### PR TITLE
Fixed failing doSearch() test.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+
+[*.js]
+indent_style = space
+indent_size = 2

--- a/lib/raneto.js
+++ b/lib/raneto.js
@@ -14,7 +14,7 @@ var lunr      = require('lunr');
 var yaml      = require('yamljs');
 
 function patch_content_dir (content_dir) {
-  return content_dir.replace('/\\', '/');
+  return content_dir.replace(/\\/g, '/');
 }
 
 var raneto = {
@@ -138,7 +138,7 @@ var raneto = {
     try {
 
       var file = fs.readFileSync(filePath),
-      slug = filePath.replace(patch_content_dir(raneto.config.content_dir), '').trim();
+      slug = patch_content_dir(filePath).replace(patch_content_dir(raneto.config.content_dir), '').trim();
 
       if (slug.indexOf('index.md') > -1) {
         slug = slug.replace('index.md', '');
@@ -268,8 +268,8 @@ var raneto = {
 
   // Index and search contents
   doSearch: function (query) {
-
-    var files = glob.sync(patch_content_dir(raneto.config.content_dir) + '**/*.md');
+    var contentDir = patch_content_dir(path.normalize(this.config.content_dir));
+    var files = glob.sync(contentDir + '**/*.md');
     var idx   = lunr(function () {
       this.field('title', { boost: 10 });
       this.field('body');
@@ -278,7 +278,7 @@ var raneto = {
     files.forEach(function (filePath) {
       try {
 
-        var shortPath = filePath.replace(patch_content_dir(raneto.config.content_dir), '').trim();
+        var shortPath = filePath.replace(contentDir, '').trim();
         var file      = fs.readFileSync(filePath);
         var meta      = raneto.processMeta(file.toString('utf-8'));
 
@@ -297,7 +297,7 @@ var raneto = {
     var searchResults = [];
 
     results.forEach(function (result) {
-      var page = raneto.getPage(patch_content_dir(raneto.config.content_dir) + result.ref);
+      var page = raneto.getPage(raneto.config.content_dir + result.ref);
       page.excerpt = page.excerpt.replace(new RegExp('('+ query +')', 'gim'), '<span class="search-query">$1</span>');
       searchResults.push(page);
     });


### PR DESCRIPTION
The `doSearch()` test was failing only in Windows.
Also added .editorconfig file so any editor can pick up project indentation
settings.